### PR TITLE
fix being unable to re-dock input pane

### DIFF
--- a/M3da/MainFrm.cpp
+++ b/M3da/MainFrm.cpp
@@ -279,6 +279,7 @@ int CMainFrame::OnCreate(LPCREATESTRUCT lpCreateStruct)
  Edit2=&m_Input.Edit2;
  Edit3=&m_Input.Edit3;
 
+ m_Input.EnableDocking(CBRS_ALIGN_ANY);
  DockPane(&m_Input);
 
  m_wndToolBar.EnableDocking(CBRS_ALIGN_ANY);


### PR DESCRIPTION
Currently, after you undock the input pane, the option to dock it back into the main window is greyed out, this PR fixes this.