### PR TITLE
Fix arrow buttons overlapping with the text input box

### DIFF
--- a/M3da/InputPane.cpp
+++ b/M3da/InputPane.cpp
@@ -65,6 +65,10 @@ void CInputPane::OnSize(UINT nType, int cx, int cy)
 
 CRect CbarSz;
 this->GetWindowRect(&CbarSz);
+
+// avoids overlapping with the arrow controls on the bottom left
+CbarSz.DeflateRect(0, 10);
+
 int h = CbarSz.Height();
 int w = CbarSz.Width();
 int TxtH = 25;


### PR DESCRIPTION
On the input box, mousing over the left side of it would cause a visual bug that made arrow buttons render over it.

This PR fixes that issue by trimming down the `CRect` where the input and output text boxes are laid out on

Before:
![before](https://github.com/user-attachments/assets/8058b343-17e0-49cf-b31a-9e5a2471c87e)

After:
![after](https://github.com/user-attachments/assets/879353fc-0cfe-476f-a317-7ae223d2eee6)
